### PR TITLE
comparando operadores do mongo no if de verificaçao de data válida, p…

### DIFF
--- a/crud/mapper.js
+++ b/crud/mapper.js
@@ -373,7 +373,8 @@ class CrudMapper {
       if (typeof data[x] === "object") {
         this.setDates(data[x], key)
       } else {
-        if (key === x && moment(data[x], moment.ISO_8601, true).isValid()) {
+        const dateComparisonOperators = ['$gt', '$gte', '$lt', '$lte', '$ne', '$eq', '$in', '$nin'];
+        if ((key === x || dateComparisonOperators.indexOf(x) > -1) && moment(data[x], moment.ISO_8601, true).isValid()) {
           data[x] = new Date(data[x]);
         }
       }


### PR DESCRIPTION
comparando operadores do mongo no if de verificaçao de data válida, pois até entao, só estava entrando na condição se valor passado fosse '=' e não '>=', '<=', etc