### PR TITLE
sorting before limit and skip for better pagination

### DIFF
--- a/crud/mapper.js
+++ b/crud/mapper.js
@@ -70,17 +70,17 @@ class CrudMapper {
     if (aggregateParam) {
       list = await this.collection.aggregate().lookup(aggregateParam)
         .match(query)
+        .sort(sort)
         .limit(pageSize)
         .skip(skip)
-        .sort(sort)
         .toArray();
     } else {
       list = await this.collection
         .find(query)
         .project(project)
+        .sort(sort)
         .limit(pageSize)
         .skip(skip)
-        .sort(sort)
         .toArray();
     }
 


### PR DESCRIPTION
Verifiquei que temos que colocar o sort antes do skip e limit pois do jeito que estava não ordenava corretamente as páginas subsequentes.